### PR TITLE
Fix the "public/storage" link already exists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /public/hot
+/public/storage
 /vendor
 /storage/*
 !/storage/app/public

--- a/database/migrations/2023_06_21_164432_create_jobs_table.php
+++ b/database/migrations/2023_06_21_164432_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/public/storage/.gitignore
+++ b/public/storage/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Issue reproduction

1. Run ```php artisan storage:link```

2. ERROR  The [public/storage] link already exists.  

The existing public/storage folder should be deleted.
